### PR TITLE
HKQuantityTypeUnitTuple: changed type from HKQuantityType to String to allow passing custom argument names

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,7 +64,7 @@ class _MyAppState extends State<MyApp> {
             start: now.subtract(Duration(days: 2)),
             end: now,
             types: [
-              HKQuantityTypeUnitTuple(HKQuantityType.StepCount, 'count'),
+              HKQuantityTypeUnitTuple(HKQuantityType.StepCount.identifier, 'count'),
             ]);
 
         setState(() {

--- a/lib/src/healthy_data_record.dart
+++ b/lib/src/healthy_data_record.dart
@@ -25,7 +25,7 @@ class HKQuantitySample with EquatableMixin {
   HKQuantitySample(this.type, this.unit, this.from, this.to, this.value);
 
   final num value;
-  final HKQuantityType type;
+  final String type;
   final String unit;
   final DateTime from;
   final DateTime to;
@@ -47,7 +47,7 @@ class HKStatistics with EquatableMixin {
   final num? avg;
   final num? min;
   final num? max;
-  final HKQuantityType type;
+  final String type;
   final String unit;
   final DateTime from;
   final DateTime to;

--- a/lib/src/healthy_hk_types.dart
+++ b/lib/src/healthy_hk_types.dart
@@ -35,14 +35,14 @@ enum HKCategoryType {
 /// A class to create a tuple of [HKQuantityType] and a [String] that matches
 /// a unit, which we want to measure the [type] in.
 class HKQuantityTypeUnitTuple with EquatableMixin {
-  final HKQuantityType type;
+  final String type;
   final String unit;
 
   const HKQuantityTypeUnitTuple(this.type, this.unit);
 
   Map<String, dynamic> toMap() {
     return {
-      'type': type.identifier,
+      'type': type,
       'unit': unit,
     };
   }
@@ -57,7 +57,7 @@ extension HKQuantityTypeX on HKQuantityType {
       'HKQuantityTypeIdentifier' + toString().split('.').last;
 
   HKQuantityTypeUnitTuple withUnit(String unit) =>
-      HKQuantityTypeUnitTuple(this, unit);
+      HKQuantityTypeUnitTuple(identifier, unit);
 }
 
 /// Extensions for the [HKCategoryType]

--- a/lib/src/healty_store.dart
+++ b/lib/src/healty_store.dart
@@ -1,9 +1,5 @@
 import 'package:flutter/services.dart';
 import 'package:healthy_ios/healthy_ios.dart';
-import 'package:healthy_ios/src/healthy_hk_types.dart';
-
-import './healthy_data_record.dart';
-import 'statistics_interval.dart';
 
 /// A class that provides Methods to access HealthKit
 class HealthStore {


### PR DESCRIPTION
Example:

```dart
await store.getHealthSamplesForQuantityType(
  start: now.subtract(const Duration(days: 2)),
  end: now,
  types: [
    const HKQuantityTypeUnitTuple('HKQuantityTypeIdentifierDietaryProtein', 'g'),
  ],
);
```